### PR TITLE
fixed solving not stopping when cube is scrambled/reset

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -156,6 +156,8 @@ class _HomePageState extends State<HomePage> {
                               }
                               sizeGetter.text = val.toString();
                               cube = RubiksCube(val);
+                              movePlayer?.cancel();
+                              movePlayer = null;
                               setState(() {});
                             },
                             color: Theme.of(context).colorScheme.secondary,
@@ -181,6 +183,8 @@ class _HomePageState extends State<HomePage> {
                                 Random().nextInt(cube.size),
                                 Random().nextBool());
                           }
+                          movePlayer?.cancel();
+                          movePlayer = null;
                           setState(() {});
                         },
                         color: Theme.of(context).colorScheme.secondary,


### PR DESCRIPTION
My first.2 pull request. Fixed small bug where solving would continue to "solve" even when the cube is scrambled again or reset, scrambling the cube more.